### PR TITLE
fix: spot.imageリサイズメソッドのnil回避追加

### DIFF
--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -26,11 +26,13 @@ class Spot < ApplicationRecord
   end
 
   def image_as_thumbnail
+    return unless image&.attached?
     return unless image.content_type.in?(%w[image/jpeg image/png])
     image.variant(resize: "250x250").processed
   end
 
   def image_as_eye_catch
+    return unless image&.attached?
     return unless image.content_type.in?(%w[image/jpeg image/png])
     image.variant(resize: "400x400").processed
   end


### PR DESCRIPTION
### 概要
- 本番環境にて、バグ発生
  - spot.imageリサイズメソッドによる影響と考えられるため対応