### PR TITLE
スポット画像がnilによるエラーの回避

### DIFF
--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -26,13 +26,17 @@ class Spot < ApplicationRecord
   end
 
   def image_as_thumbnail
-    return unless image&.attached?
+    unless image&.attached?
+      "app/assets/images/spot_default.png"
+    end
     return unless image.content_type.in?(%w[image/jpeg image/png])
     image.variant(resize_to_limit: [ 250, 250 ]).processed
   end
 
   def image_as_eye_catch
-    return unless image&.attached?
+    unless image&.attached?
+      "app/assets/images/spot_default.png"
+    end
     return unless image.content_type.in?(%w[image/jpeg image/png])
     image.variant(resize_to_limit: [ 400, 400 ]).processed
   end


### PR DESCRIPTION
### 概要
- スポット画像がnilのimage_tagでエラーがでたため、デフォルト画像を用意することで回避