### PR TITLE
画像なしスポットのエラーに対処

### DIFF
--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -26,17 +26,11 @@ class Spot < ApplicationRecord
   end
 
   def image_as_thumbnail
-    unless image&.attached?
-      "app/assets/images/spot_default.png"
-    end
     return unless image.content_type.in?(%w[image/jpeg image/png])
     image.variant(resize_to_limit: [ 250, 250 ]).processed
   end
 
   def image_as_eye_catch
-    unless image&.attached?
-      "app/assets/images/spot_default.png"
-    end
     return unless image.content_type.in?(%w[image/jpeg image/png])
     image.variant(resize_to_limit: [ 400, 400 ]).processed
   end

--- a/app/views/spots/_spot.html.erb
+++ b/app/views/spots/_spot.html.erb
@@ -6,7 +6,11 @@
           <div class="card-body">
             <div class="row justify-content-around">
               <div class="col-md-3">
-                <%= image_tag spot.image_as_thumbnail %>
+                <% unless spot.image.attached? %>
+                  <%= image_tag "spot_default.png", size: "250x250" %>
+                <% else %>
+                  <%= image_tag spot.image_as_thumbnail %>
+                <% end %>
               </div>
               <div class="col-md-8">
                 <div class="row">

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -14,7 +14,11 @@
   </div>
   <div class="row justify-content-around">
     <div class="col-4">
-      <%= image_tag @spot.image_as_eye_catch %>
+      <% unless @spot.image.attached? %>
+        <%= image_tag "spot_default.png", size: "400x400" %>
+      <% else %>
+        <%= image_tag @spot.image_as_eye_catch %>
+      <% end %>
     </div>
       <div class="col-7">
         <% if user_signed_in? && current_user.own?(@spot) %>


### PR DESCRIPTION
### 概要
- 本番環境に画像が保存されていないスポットが登録されていたために、image_tagの値がnilとなりエラーがでていた
  - 画像がない場合には、デフォルト画像を表示するように修正