### PR TITLE
fix:スポット画像がない場合のエラーを修正（デフォルト画像を用意）

### DIFF
--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -27,12 +27,20 @@ class Spot < ApplicationRecord
   end
 
   def image_as_thumbnail
-    return unless image.content_type.in?(%w[image/jpeg image/png])
-    image.variant(resize_to_limit: [ 250, 250 ]).processed
+    if image.attached?
+      return unless image.content_type.in?(%w[image/jpeg image/png])
+      image.variant(resize_to_limit: [ 250, 250 ]).processed
+    else
+      return "spot_default.png", size: "250x250"
+    end
   end
 
   def image_as_eye_catch
-    return unless image.content_type.in?(%w[image/jpeg image/png])
-    image.variant(resize_to_limit: [ 400, 400 ]).processed
+    if image.attached?
+      return unless image.content_type.in?(%w[image/jpeg image/png])
+      image.variant(resize_to_limit: [ 400, 400 ]).processed
+    else
+      return "spot_default.png", size: "400x400"
+    end
   end
 end

--- a/app/views/spots/_spot.html.erb
+++ b/app/views/spots/_spot.html.erb
@@ -6,11 +6,7 @@
           <div class="card-body">
             <div class="row justify-content-around">
               <div class="col-md-3">
-                <% unless spot.image.attached? %>
-                  <%= image_tag "spot_default.png", size: "250x250" %>
-                <% else %>
-                  <%= image_tag spot.image_as_thumbnail %>
-                <% end %>
+                <%= image_tag spot.image_as_thumbnail %>
               </div>
               <div class="col-md-8">
                 <div class="row">

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -14,11 +14,7 @@
   </div>
   <div class="row justify-content-around">
     <div class="col-4">
-      <% unless @spot.image.attached? %>
-        <%= image_tag "spot_default.png", size: "400x400" %>
-      <% else %>
-        <%= image_tag @spot.image_as_eye_catch %>
-      <% end %>
+      <%= image_tag @spot.image_as_eye_catch %>
     </div>
       <div class="col-7">
         <% if user_signed_in? && current_user.own?(@spot) %>


### PR DESCRIPTION
### 概要
- 本番環境にてスポット画像がない場合にでるエラーがみられた
  - 現在はスポット投稿時に画像がない場合にはデフォルト画像を保存するように仕様を変更
  - エラー回避のため、保存画像がない場合にはデフォルト画像が表示されるように編集