### PR TITLE
コメントのレーティングを星表示に変更

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -1,2 +1,27 @@
 @import 'bootstrap/scss/bootstrap';
 @import 'bootstrap-icons/font/bootstrap-icons';
+
+.rate-form {
+  display: flex;
+  flex-direction: row-reverse;
+  justify-content: flex-end;
+}
+.rate-form input[type=radio] {
+  display: none;
+}
+.rate-form label {
+  position: relative;
+  padding: 0 5px;
+  color: #ccc;
+  cursor: pointer;
+  font-size: 35px;
+}
+.rate-form label:hover {
+  color: #ffcc00;
+}
+.rate-form label:hover ~ label {
+  color: #ffcc00;
+}
+.rate-form input[type=radio]:checked ~ label {
+  color: #ffcc00;
+}

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -25,7 +25,7 @@
         </tr>
         <tr>
           <th scope="row" class="text-center">おすすめ度</th>
-          <td><%= "#{comment.rating_i18n}" %></td>
+          <td style="color:#ffcc00"><%= "#{comment.rating_i18n}" %></td>
         </tr>
         <tr>
           <th scope="row" class="text-center">本文</th>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -28,8 +28,17 @@
       <div class="col-6 mb-1 mx-auto">
         <%= f.label :rating %>
       </div>
-      <div class="col-6 mb-4 mx-auto">
-        <%= f.select :rating, Comment.ratings.keys.map { |k| [t("enums.comment.rating.#{k}"), k ]}, class: "form-control" %>
+      <div class="col-6 mb-4 mx-auto rate-form">
+        <%= f.radio_button :rating, :star_5 %>
+        <label for="comment_rating_star_5">★</label>
+        <%= f.radio_button :rating, :star_4 %>
+        <label for="comment_rating_star_4">★</label>
+        <%= f.radio_button :rating, :star_3 %>
+        <label for="comment_rating_star_3">★</label>
+        <%= f.radio_button :rating, :star_2 %>
+        <label for="comment_rating_star_2">★</label>
+        <%= f.radio_button :rating, :star_1 %>
+        <label for="comment_rating_star_1">★</label>
       </div>
       <div class="col-6 mb-4 mx-auto">
         <%= f.label :title %>

--- a/app/views/comments/show.html.erb
+++ b/app/views/comments/show.html.erb
@@ -68,7 +68,7 @@
                 </tr>
                 <tr>
                   <th scope="row" class="text-center">おすすめ度</th>
-                  <td><%= "#{@comment.rating_i18n}" %></td>
+                  <td style="color:#ffcc00"><%= "#{@comment.rating_i18n}" %></td>
                 </tr>
                 <tr>
                   <th scope="row" class="text-center">本文</th>

--- a/config/locales/enums/ja.yml
+++ b/config/locales/enums/ja.yml
@@ -12,8 +12,8 @@ ja:
         manual_work: 手作業
         reading: 読書
       rating:
-        star_1: ☆
-        star_2: ☆☆
-        star_3: ☆☆☆
-        star_4: ☆☆☆☆
-        star_5: ☆☆☆☆☆
+        star_1: ★
+        star_2: ★★
+        star_3: ★★★
+        star_4: ★★★★
+        star_5: ★★★★★


### PR DESCRIPTION
### 概要
- コメントのレーティングを星表示に変更
  - 当初はratyを使用する予定だったが、ラジオボタンをHTML、CSSで編集し実装
  - スポット一覧、詳細画面は平均値のため、星表示はしていない（後に星表示にする予定）