### PR TITLE
スポット画像が存在しない場合のOGPのエラー

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -49,13 +49,13 @@ module ApplicationHelper
           description: :description,
           type: "website",
           url: request.original_url,
-          image: image_url(url_for(@spot.image)),
+          image: image_url(@spot.image.present? ? url_for(@spot.image) : "top_image.png"),
           local: "ja-JP"
         },
         twitter: {
           card: "summary_large_image",
           site: "@yuya_ujiie",
-          image: image_url(url_for(@spot.image))
+          image: image_url(@spot.image.present? ? url_for(@spot.image) : "top_image.png")
         }
       }
     end


### PR DESCRIPTION
### 概要
- 本番環境にてスポット画像が存在しない場合、OGPがnilとなったためエラーが生じた
  （スポット登録時に画像がない場合には、デフォルト画像を保存するようになったため、本エラーは今後回避済み）
- スポット画像がない場合には、デフォルト画像をOGPとするように編集