### PR TITLE
スポット編集時のタグの動態修正

### DIFF
--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -53,8 +53,11 @@ class SpotsController < ApplicationController
 
   # PATCH/PUT /spots/1 or /spots/1.json
   def update
+    tag_list = params[:spot][:tag_ids].split(",")
+
     respond_to do |format|
       if @spot.update(spot_params)
+        @spot.save_tags(tag_list)
         format.html { redirect_to @spot, notice: "スポットを編集しました" }
         format.json { render :show, status: :ok, location: @spot }
       else

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -46,10 +46,18 @@ class Spot < ApplicationRecord
     image.variant(resize_to_limit: [ 400, 400 ]).processed
   end
 
-  def save_tags(savepost_tags)
-    savepost_tags.each do |new_name|
-      post_tag = Tag.find_or_create_by(name: new_name)
-      self.tags << post_tag
+  def save_tags(save_post_tags)
+    current_tags = self.tags.pluck(:name) if self.tags.present?
+    old_tags = current_tags - save_post_tags
+    new_tags = save_post_tags - current_tags
+
+    old_tags.each do |old_tag|
+      self.tags.delete Tag.find_by(name: old_tag)
+    end
+
+    new_tags.each do |new_tag|
+      spot_tag = Tag.find_or_create_by(name: new_tag)
+      self.tags << spot_tag
     end
   end
 end

--- a/app/views/spots/_form.html.erb
+++ b/app/views/spots/_form.html.erb
@@ -30,7 +30,7 @@
         </div>
         <div class="mb-3">
           <%= f.label :tag_ids, "タグ　,で区切ると複数タグ登録できます" %>
-          <%= f.text_field :tag_ids, class: "form-control" %>
+          <%= f.text_field :tag_ids, class: "form-control", value: spot.tags.map(&:name).join(",") %>
         </div>
         <div class="mb-3">
           <%= f.label :image %>

--- a/app/views/spots/_spot.html.erb
+++ b/app/views/spots/_spot.html.erb
@@ -19,7 +19,7 @@
                     <h3><%= link_to spot.spot_name, spot_path(spot) %></h3>
                     <% spot.tags.each do |tag| %>
                       <%= link_to spots_path(tag_id: tag.id) do %>
-                        <span class="badge text-bg-primary"><%= "#{ tag.name }" %></span>
+                        <span class="badge rounded-pill text-bg-primary"><%= "#{ tag.name }" %></span>
                       <% end %>
                     <% end %>
                   </div>


### PR DESCRIPTION
### 概要
- スポット編集時にタグ入力にタグ名ではなく、idが記載されているバグあり
  - f.text_filedにvalueオプションにタグを表示させるように修正
- スポット編集時にタグを追加、削除した場合、正しく動いていなかったため修正
  - save_tagsメソッドを修正し改善