### PR TITLE
スポット投稿時のエラー対処

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,6 @@
 module ApplicationHelper
   def assign_meta_tags
-    if @spot.nil?
+    if @spot.blank?
       {
         site: "Morning Hub",
         title: "朝活スポット検索アプリ - Morning Hub",
@@ -49,13 +49,13 @@ module ApplicationHelper
           description: :description,
           type: "website",
           url: request.original_url,
-          image: image_url(@spot.image.present? ? url_for(@spot.image) : "top_image.png"),
+          image: image_url(@spot.image.persisted? ? url_for(@spot.image) : "top_image.png"),
           local: "ja-JP"
         },
         twitter: {
           card: "summary_large_image",
           site: "@yuya_ujiie",
-          image: image_url(@spot.image.present? ? url_for(@spot.image) : "top_image.png")
+          image: image_url(@spot.image.persisted? ? url_for(@spot.image) : "top_image.png")
         }
       }
     end

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -47,7 +47,7 @@ class Spot < ApplicationRecord
   end
 
   def save_tags(save_post_tags)
-    current_tags = self.tags.pluck(:name) if self.tags.present?
+    current_tags = self.tags.pluck(:name)
     old_tags = current_tags - save_post_tags
     new_tags = save_post_tags - current_tags
 


### PR DESCRIPTION
### エラー内容
- スポット投稿時にmeta_tags関連のエラーがでていた
  - スポット投稿がバリデーションエラーなどで失敗した場合を、meta_tags内のメソッドで考慮していなかった
- スポット投稿時のtag保存にエラーができていた

### 対処
- meta_tags内のメソッド（主に判別系）を修正
- tag保存のメソッドを修正