### PR TITLE
UUIDの実装

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,4 +1,6 @@
 class Comment < ApplicationRecord
+  before_create :set_uuid
+
   validates :scene, presence: true
   validates :start_at, presence: true
   validates :finish_at, presence: true
@@ -11,4 +13,8 @@ class Comment < ApplicationRecord
 
   enum scene: { pc_work: 0, manual_work: 1, reading: 2 }
   enum rating: { star_1: 1, star_2: 2, star_3: 3, star_4: 4, star_5: 5 }
+
+  def set_uuid
+    self.id = SecureRandom.uuid
+  end
 end

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -1,4 +1,6 @@
 class Spot < ApplicationRecord
+  before_create :set_uuid
+
   validates :spot_name, presence: true, length: { maximum: 255 }
   validates :category, presence: true
   validates :address, presence: true, length: { maximum: 255 }
@@ -59,5 +61,9 @@ class Spot < ApplicationRecord
       spot_tag = Tag.find_or_create_by(name: new_tag)
       self.tags << spot_tag
     end
+  end
+
+  def set_uuid
+    self.id = SecureRandom.uuid
   end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,6 +1,12 @@
 class Tag < ApplicationRecord
+  before_create :set_uuid
+
   has_many :spot_tags, dependent: :destroy
   has_many :spots, through: :spot_tags
 
   validates :name, presence: true, uniqueness: true
+
+  def set_uuid
+    self.id = SecureRandom.uuid
+  end
 end

--- a/db/migrate/20241118100345_create_spots.rb
+++ b/db/migrate/20241118100345_create_spots.rb
@@ -1,11 +1,13 @@
 class CreateSpots < ActiveRecord::Migration[7.2]
   def change
-    create_table :spots do |t|
-      t.references :user, foreign_key: true
+    create_table :spots, id: :string do |t|
+      t.references :user, null: false, foreign_key: true
       t.string :spot_name, null: false
       t.integer :category, null: false
       t.string :address, null: false
       t.text :body, null: false
+      t.float :latitude
+      t.float :longitude
       t.timestamps
     end
   end

--- a/db/migrate/20241125095901_create_comments.rb
+++ b/db/migrate/20241125095901_create_comments.rb
@@ -1,8 +1,8 @@
 class CreateComments < ActiveRecord::Migration[7.2]
   def change
-    create_table :comments do |t|
-      t.references :user, foreign_key: true
-      t.references :spot, foreign_key: true
+    create_table :comments, id: :string do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :spot, null: false, foreign_key: true, type: :string
       t.integer :scene, null: false
       t.integer :rating, null: false
       t.time :start_at, null: false

--- a/db/migrate/20250106063925_create_bookmarks.rb
+++ b/db/migrate/20250106063925_create_bookmarks.rb
@@ -1,8 +1,8 @@
 class CreateBookmarks < ActiveRecord::Migration[7.2]
   def change
     create_table :bookmarks do |t|
-      t.references :user, foreign_key: true
-      t.references :spot, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.references :spot, null: false, foreign_key: true, type: :string
 
       t.timestamps
     end

--- a/db/migrate/20250110014437_create_tags.rb
+++ b/db/migrate/20250110014437_create_tags.rb
@@ -1,6 +1,6 @@
 class CreateTags < ActiveRecord::Migration[7.2]
   def change
-    create_table :tags do |t|
+    create_table :tags, id: :string do |t|
       t.string :name, null: false
 
       t.timestamps

--- a/db/migrate/20250110014458_create_spot_tags.rb
+++ b/db/migrate/20250110014458_create_spot_tags.rb
@@ -1,8 +1,8 @@
 class CreateSpotTags < ActiveRecord::Migration[7.2]
   def change
     create_table :spot_tags do |t|
-      t.references :spot, null: false, foreign_key: true
-      t.references :tag, null: false, foreign_key: true
+      t.references :spot, null: false, foreign_key: true, type: :string
+      t.references :tag, null: false, foreign_key: true, type: :string
 
       t.timestamps
     end

--- a/db/migrate/20250128050912_add_omniauth_to_users.rb
+++ b/db/migrate/20250128050912_add_omniauth_to_users.rb
@@ -2,5 +2,7 @@ class AddOmniauthToUsers < ActiveRecord::Migration[7.2]
   def change
     add_column :users, :provider, :string
     add_column :users, :uid, :string
+
+    add_index :users, [ :provider, :uid ], unique: true
   end
 end

--- a/db/migrate/20250128052053_add_index_uid_and_provider_to_users.rb
+++ b/db/migrate/20250128052053_add_index_uid_and_provider_to_users.rb
@@ -1,5 +1,0 @@
-class AddIndexUidAndProviderToUsers < ActiveRecord::Migration[7.2]
-  def change
-    add_index :users, [ :provider, :uid ], unique: true
-  end
-end

--- a/db/migrate/20250203031411_add_column_to_spots.rb
+++ b/db/migrate/20250203031411_add_column_to_spots.rb
@@ -1,6 +1,0 @@
-class AddColumnToSpots < ActiveRecord::Migration[7.2]
-  def change
-    add_column :spots, :latitude, :float
-    add_column :spots, :longitude, :float
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_03_031411) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_28_050912) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -40,8 +40,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_03_031411) do
   end
 
   create_table "bookmarks", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.bigint "user_id"
-    t.bigint "spot_id"
+    t.bigint "user_id", null: false
+    t.string "spot_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["spot_id"], name: "index_bookmarks_on_spot_id"
@@ -49,25 +49,24 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_03_031411) do
     t.index ["user_id"], name: "index_bookmarks_on_user_id"
   end
 
-  create_table "comments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.bigint "user_id"
-    t.bigint "spot_id"
+  create_table "comments", id: :string, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "spot_id", null: false
     t.integer "scene", null: false
+    t.integer "rating", null: false
     t.time "start_at", null: false
     t.time "finish_at", null: false
-    t.integer "rating", null: false
     t.string "title", null: false
     t.text "body", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "star"
     t.index ["spot_id"], name: "index_comments_on_spot_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
   create_table "spot_tags", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.bigint "spot_id", null: false
-    t.bigint "tag_id", null: false
+    t.string "spot_id", null: false
+    t.string "tag_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["spot_id", "tag_id"], name: "index_spot_tags_on_spot_id_and_tag_id", unique: true
@@ -75,20 +74,20 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_03_031411) do
     t.index ["tag_id"], name: "index_spot_tags_on_tag_id"
   end
 
-  create_table "spots", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.bigint "user_id"
+  create_table "spots", id: :string, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "user_id", null: false
     t.string "spot_name", null: false
     t.integer "category", null: false
     t.string "address", null: false
     t.text "body", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.float "latitude"
     t.float "longitude"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_spots_on_user_id"
   end
 
-  create_table "tags", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "tags", id: :string, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
### 概要
- SQLインジェクションの問題があるため、URLにidが記載されるテーブルのidをuuidに変更

### 実装内容
- spots、comments、tagsテーブルをuuidに変更
  - idの型をstringに変更
  - 各modelにbefore_createでset_uuidメソッドを追加しuuidを生成
- uuid変更のFKをstring型に変更