### PR TITLE
active_storage関連のエラーの修正

### DIFF
--- a/db/migrate/20250226031501_change_active_storage_record_references_to_string.rb
+++ b/db/migrate/20250226031501_change_active_storage_record_references_to_string.rb
@@ -1,0 +1,6 @@
+class ChangeActiveStorageRecordReferencesToString < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :active_storage_attachments, :record_id
+    add_column :active_storage_attachments, :record_id, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,15 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_28_050912) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_26_031501) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.bigint "record_id", null: false
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
+    t.string "record_id", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
-    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+    t.index ["record_type", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
   create_table "active_storage_blobs", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -40,8 +40,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_28_050912) do
   end
 
   create_table "bookmarks", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.string "spot_id", null: false
+    t.bigint "user_id"
+    t.bigint "spot_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["spot_id"], name: "index_bookmarks_on_spot_id"
@@ -49,24 +49,25 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_28_050912) do
     t.index ["user_id"], name: "index_bookmarks_on_user_id"
   end
 
-  create_table "comments", id: :string, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.string "spot_id", null: false
+  create_table "comments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "spot_id"
     t.integer "scene", null: false
-    t.integer "rating", null: false
     t.time "start_at", null: false
     t.time "finish_at", null: false
+    t.integer "rating", null: false
     t.string "title", null: false
     t.text "body", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "star"
     t.index ["spot_id"], name: "index_comments_on_spot_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
   create_table "spot_tags", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string "spot_id", null: false
-    t.string "tag_id", null: false
+    t.bigint "spot_id", null: false
+    t.bigint "tag_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["spot_id", "tag_id"], name: "index_spot_tags_on_spot_id_and_tag_id", unique: true
@@ -74,20 +75,20 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_28_050912) do
     t.index ["tag_id"], name: "index_spot_tags_on_tag_id"
   end
 
-  create_table "spots", id: :string, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.bigint "user_id", null: false
+  create_table "spots", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "user_id"
     t.string "spot_name", null: false
     t.integer "category", null: false
     t.string "address", null: false
     t.text "body", null: false
-    t.float "latitude"
-    t.float "longitude"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.float "latitude"
+    t.float "longitude"
     t.index ["user_id"], name: "index_spots_on_user_id"
   end
 
-  create_table "tags", id: :string, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "tags", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
### 概要
- スポット削除時に、active_storage周りのエラーが出現するため修正する

### 修正内容
- uuid実装時に、active_storage_attachmentsテーブルのrecord_idのデータ型を揃えていなかったためにエラーがでていた
  - record_idをstring型に変更することでエラー解決