### PR TITLE
google_analyticsの追加

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,6 +12,16 @@
     <link rel="manifest" href="/manifest.json">
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
+
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-DHXSFBNWPL"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-DHXSFBNWPL');
+    </script>
   </head>
 
   <body class="d-flex flex-column vh-100">


### PR DESCRIPTION
### 概要
- アプリへのアクセス数把握のために、Google analyticsを導入

### 実装内容
- Google analyticsのアカウント作成
- application.html.erb headタグ内に、Google analyticsのタグを追加