### PR TITLE
おすすめ度の表示変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,7 @@ gem "rambulance"
 
 gem "kaminari"
 
-gem 'draper'
+gem "draper"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,8 @@ gem "rambulance"
 
 gem "kaminari"
 
+gem 'draper'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,10 @@ GEM
       globalid (>= 0.3.6)
     activemodel (7.2.2)
       activesupport (= 7.2.2)
+    activemodel-serializers-xml (1.0.3)
+      activemodel (>= 5.0.0.a)
+      activesupport (>= 5.0.0.a)
+      builder (~> 3.1)
     activerecord (7.2.2)
       activemodel (= 7.2.2)
       activesupport (= 7.2.2)
@@ -146,6 +150,13 @@ GEM
     dotenv-rails (3.1.7)
       dotenv (= 3.1.7)
       railties (>= 6.1)
+    draper (4.0.4)
+      actionpack (>= 5.0)
+      activemodel (>= 5.0)
+      activemodel-serializers-xml (>= 1.0)
+      activesupport (>= 5.0)
+      request_store (>= 1.0)
+      ruby2_keywords
     drb (2.2.1)
     enum_help (0.0.19)
       activesupport (>= 3.0.0)
@@ -347,6 +358,8 @@ GEM
     regexp_parser (2.9.2)
     reline (0.5.10)
       io-console (~> 0.5)
+    request_store (1.7.0)
+      rack (>= 1.4)
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
@@ -401,6 +414,7 @@ GEM
     ruby-vips (2.2.2)
       ffi (~> 1.12)
       logger
+    ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     securerandom (0.3.1)
     selenium-webdriver (4.26.0)
@@ -479,6 +493,7 @@ DEPENDENCIES
   devise
   devise-i18n-views
   dotenv-rails
+  draper
   enum_help
   factory_bot_rails
   geocoder

--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -32,6 +32,13 @@ body {
   color: #ffcc00;
 }
 
+.rate-show {
+  position: relative;
+  padding: 0 5px;
+  color: #ccc;
+  font-size: 20px;
+}
+
 #map {
   height: 300px;
   width: 100%;

--- a/app/decorators/spot_decorator.rb
+++ b/app/decorators/spot_decorator.rb
@@ -1,0 +1,22 @@
+class SpotDecorator < Draper::Decorator
+  delegate_all
+
+  def average_star
+    average = object.comments.average(:rating)&.round
+    case average
+    when 0
+      ""
+    when 1
+      "★☆☆☆☆"
+    when 2
+      "★★☆☆☆"
+    when 3
+      "★★★☆☆"
+    when 4
+      "★★★★☆"
+    when 5
+      "★★★★★"
+    end
+  end
+
+end

--- a/app/decorators/spot_decorator.rb
+++ b/app/decorators/spot_decorator.rb
@@ -18,5 +18,4 @@ class SpotDecorator < Draper::Decorator
       "★★★★★"
     end
   end
-
 end

--- a/app/views/spots/_spot.html.erb
+++ b/app/views/spots/_spot.html.erb
@@ -48,7 +48,7 @@
                 </div>
                 <ul class="list-group list-group-flush">
                   <li class="list-group-item bg-body-tertiary"><%= "#{spot.address}" %></li>
-                  <li class="list-group-item bg-body-tertiary">おすすめ度：<%= "#{spot.comments.average(:rating)}" %></li>
+                  <li class="list-group-item bg-body-tertiary">おすすめ度：<%= "#{spot.comments.average(:rating)&.round(1)}" %></li>
                   <li class="list-group-item bg-body-tertiary"><%= "#{spot.body}" %></li>
                 </ul>
               </div>

--- a/app/views/spots/_spot.html.erb
+++ b/app/views/spots/_spot.html.erb
@@ -48,7 +48,9 @@
                 </div>
                 <ul class="list-group list-group-flush">
                   <li class="list-group-item bg-body-tertiary"><%= "#{spot.address}" %></li>
-                  <li class="list-group-item bg-body-tertiary">おすすめ度：<%= "#{spot.comments.average(:rating)&.round(1)}" %></li>
+                  <li class="list-group-item bg-body-tertiary">おすすめ度：<%= "#{spot.comments.average(:rating)&.round(1)}" %>
+                    <span class="rate-show" style="color:#ffcc00"><%= "#{spot.decorate.average_star}" %></span>
+                  </li>
                   <li class="list-group-item bg-body-tertiary"><%= "#{spot.body}" %></li>
                 </ul>
               </div>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -69,7 +69,9 @@
           </tr>
           <tr>
             <th scope="row" class="text-center">おすすめ度</th>
-            <td><%= "#{@spot.comments.average(:rating)&.round(1)}" %></td>
+            <td><%= "#{@spot.comments.average(:rating)&.round(1)}" %>
+              <span class="rate-show" style="color:#ffcc00"><%= "#{@spot.decorate.average_star}" %></span></li>
+            </td>
           </tr>
           <tr>
             <th scope="row" class="text-center">説明</th>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -69,7 +69,7 @@
           </tr>
           <tr>
             <th scope="row" class="text-center">おすすめ度</th>
-            <td><%= "#{@spot.comments.average(:rating)}" %></td>
+            <td><%= "#{@spot.comments.average(:rating)&.round(1)}" %></td>
           </tr>
           <tr>
             <th scope="row" class="text-center">説明</th>


### PR DESCRIPTION
### 実装概要
- おすすめ度（commentのratingを平均したもの）がわかりにくかったため、星と少数第1位の数字で表示するように変更する

### 実装内容
- 星表示はdecoratorで実装
  - 平均値を四捨五入したもので場合分け
- 数値は四捨五入し、少数第1位まで表示