### PR TITLE
スポット作成時のオートコンプリート

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,7 @@
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
 
-    <!-- Google tag (gtag.js) -->
+    <!-- Google analystics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-DHXSFBNWPL"></script>
     <script>
       window.dataLayer = window.dataLayer || [];

--- a/app/views/spots/_form.html.erb
+++ b/app/views/spots/_form.html.erb
@@ -13,7 +13,7 @@
 
       <div class="col-md-6 mb-3 mx-auto">
         <%= f.label :spot_name %>
-        <%= f.text_field :spot_name, class: "form-control" %>
+        <%= f.text_field :spot_name, id: "autocomplete", class: "form-control" %>
       </div>
       <div class="col-md-6 mb-3 mx-auto">
         <%= f.label :category %>
@@ -21,7 +21,7 @@
       </div>
       <div class="col-md-6 mb-3 mx-auto">
         <%= f.label :address %>
-        <%= f.text_field :address, class: "form-control" %>
+        <%= f.text_field :address, id: "address", class: "form-control" %>
       </div>
       <div class="col-md-6 mb-3 mx-auto">
         <%= f.label :body %>
@@ -41,3 +41,25 @@
     <% end %>
   </div>
 </div>
+
+<script>
+  let autocomplete;
+  function initAutocomplete() {
+    autocomplete = new google.maps.places.Autocomplete(
+      document.getElementById("autocomplete"),
+      {
+        types: ['establishment'],
+        componentRestrictions: { "country": 'JP' },
+      }
+    );
+
+    autocomplete.addListener("place_changed", onPlaceChanged);
+  }
+
+  function onPlaceChanged(){
+    const place = autocomplete.getPlace();
+    document.getElementById("autocomplete").value = place.name;
+    document.getElementById("address").value = place.formatted_address;
+  }
+</script>
+<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAP_API_KEY'] %>&loading=async&libraries=places&callback=initAutocomplete" async defer></script>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -64,10 +64,6 @@
             <td><%= "#{@spot.category_i18n}" %></td>
           </tr>
           <tr>
-            <th scope="row" class="text-center">投稿者</th>
-            <td><%= "#{@spot.user.name}" %></td>
-          </tr>
-          <tr>
             <th scope="row" class="text-center">おすすめ度</th>
             <td><%= "#{@spot.comments.average(:rating)&.round(1)}" %>
               <span class="rate-show" style="color:#ffcc00"><%= "#{@spot.decorate.average_star}" %></span></li>
@@ -76,6 +72,10 @@
           <tr>
             <th scope="row" class="text-center">説明</th>
             <td><%=  "#{@spot.body}" %></td>
+          </tr>
+          <tr>
+            <th scope="row" class="text-center">住所</th>
+            <td><%=  "#{@spot.address}" %></td>
           </tr>
           <tr>
             <th scope="row" class="text-center">マップ</th>

--- a/spec/system/spots_spec.rb
+++ b/spec/system/spots_spec.rb
@@ -75,9 +75,9 @@ RSpec.describe "Spots", type: :system do
       context "フォームの入力値が正常" do
         it "新規作成が成功する" do
           visit new_spot_path
-          fill_in "店名", with: "朝活カフェ"
+          fill_in "spot[spot_name]", with: "朝活カフェ"
           select "カフェ", from: "カテゴリ"
-          fill_in "住所", with: "北海道札幌市"
+          fill_in "spot[address]", with: "北海道札幌市"
           fill_in "説明", with: "テスト"
           fill_in "タグ", with: "テスト,tag"
           click_button "登録"
@@ -89,9 +89,9 @@ RSpec.describe "Spots", type: :system do
       context "店名が未記入" do
         it "新規作成が失敗する" do
           visit new_spot_path
-          fill_in "店名", with: nil
+          fill_in "spot[spot_name]", with: nil
           select "カフェ", from: "カテゴリ"
-          fill_in "住所", with: "北海道札幌市"
+          fill_in "spot[address]", with: "北海道札幌市"
           fill_in "説明", with: "テスト"
           fill_in "タグ", with: "テスト,tag"
           click_button "登録"
@@ -106,7 +106,7 @@ RSpec.describe "Spots", type: :system do
         it "編集が成功する" do
           visit edit_spot_path(spot)
           expect(page).to have_content "スポット編集"
-          fill_in "店名", with: "朝活カフェ"
+          fill_in "spot[spot_name]", with: "朝活カフェ"
           click_button "更新"
           expect(page).to have_content "スポットを編集しました"
           expect(page).to have_content "朝活カフェ"
@@ -117,7 +117,7 @@ RSpec.describe "Spots", type: :system do
         it "編集が失敗する" do
           visit edit_spot_path(spot)
           expect(page).to have_content "スポット編集"
-          fill_in "店名", with: nil
+          fill_in "spot[spot_name]", with: nil
           click_button "更新"
           expect(page).to have_content "店名を入力してください"
           expect(current_path).to eq edit_spot_path(spot)


### PR DESCRIPTION
### 実装概要
- スポット作成時に店名、住所を調べなければならず、ユーザビリティに欠けている
- google map API（Places API）によるオートコンプリートにより改善を図る

### 実装内容
- Places API
  - 店名入力によるオートコンプリートを実装
  - 店名選択により住所も自動入力される
- system test
  - オートコンプリート実装時にフォームのidを変更したことでfill_inの指定が変化しテスト失敗
    - fill_inの指定を変更しテスト成功

### メモ
- google map APIは2025年3月より課金制度が変更となったため、APIの使用程度をgoogle cloud consoleでチェック必要