### PR TITLE
validationの追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,7 @@ group :development, :test do
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
 
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
-  gem "brakeman", "~> 7.0.0", require: false
+  gem "brakeman", "~> 7.0.2", require: false
 
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false

--- a/Gemfile
+++ b/Gemfile
@@ -92,6 +92,8 @@ group :development do
   gem "letter_opener_web"
 
   gem "bullet"
+
+  gem "annotate"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,9 @@ GEM
       tzinfo (~> 2.0, >= 2.0.5)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
+    annotate (3.2.0)
+      activerecord (>= 3.2, < 8.0)
+      rake (>= 10.4, < 14.0)
     ast (2.4.2)
     aws-eventstream (1.3.0)
     aws-partitions (1.1009.0)
@@ -480,6 +483,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  annotate
   aws-sdk-s3
   better_errors
   binding_of_caller

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,7 +111,7 @@ GEM
       debug_inspector (>= 1.2.0)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
-    brakeman (7.0.0)
+    brakeman (7.0.2)
       racc
     builder (3.3.0)
     bullet (8.0.1)
@@ -488,7 +488,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   bootsnap
-  brakeman (~> 7.0.0)
+  brakeman (~> 7.0.2)
   bullet
   capybara
   chartkick

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: bookmarks
+#
+#  id         :bigint           not null, primary key
+#  user_id    :bigint           not null
+#  spot_id    :string(255)      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 class Bookmark < ApplicationRecord
   belongs_to :user
   belongs_to :spot

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: comments
+#
+#  id         :string(255)      not null, primary key
+#  user_id    :bigint           not null
+#  spot_id    :string(255)      not null
+#  scene      :integer          not null
+#  rating     :integer          not null
+#  start_at   :time             not null
+#  finish_at  :time             not null
+#  title      :string(255)      not null
+#  body       :text(65535)      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 class Comment < ApplicationRecord
   before_create :set_uuid
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -4,6 +4,7 @@ class Comment < ApplicationRecord
   validates :scene, presence: true
   validates :start_at, presence: true
   validates :finish_at, presence: true
+  validates :finish_at, comparison: { greater_than_or_equal_to: :start_at }
   validates :rating, presence: true
   validates :title, presence: true, length: { maximum: 255 }
   validates :body, presence: true, length: { maximum: 65_535 }

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -28,8 +28,8 @@ class Comment < ApplicationRecord
   belongs_to :user
   belongs_to :spot
 
-  enum scene: { pc_work: 0, manual_work: 1, reading: 2 }
-  enum rating: { star_1: 1, star_2: 2, star_3: 3, star_4: 4, star_5: 5 }
+  enum :scene, { pc_work: 0, manual_work: 1, reading: 2, other: 99}
+  enum :rating, { star_1: 1, star_2: 2, star_3: 3, star_4: 4, star_5: 5 }
 
   def set_uuid
     self.id = SecureRandom.uuid

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -28,7 +28,7 @@ class Comment < ApplicationRecord
   belongs_to :user
   belongs_to :spot
 
-  enum :scene, { pc_work: 0, manual_work: 1, reading: 2, other: 99}
+  enum :scene, { pc_work: 0, manual_work: 1, reading: 2, other: 99 }
   enum :rating, { star_1: 1, star_2: 2, star_3: 3, star_4: 4, star_5: 5 }
 
   def set_uuid

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -31,7 +31,7 @@ class Spot < ApplicationRecord
 
   has_one_attached :image
 
-  enum category: { cafe: 1, work_space: 2, karaoke: 3, other: 4 }
+  enum :category, { cafe: 1, work_space: 2, karaoke: 3, other: 4 }
 
   scope :spot_name_contain, ->(word) { where("spot_name LIKE ?", "%#{word}%") }
   scope :by_category, ->(category) { where(category: category) }

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: spots
+#
+#  id         :string(255)      not null, primary key
+#  user_id    :bigint           not null
+#  spot_name  :string(255)      not null
+#  category   :integer          not null
+#  address    :string(255)      not null
+#  body       :text(65535)      not null
+#  latitude   :float(24)
+#  longitude  :float(24)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 class Spot < ApplicationRecord
   before_create :set_uuid
 

--- a/app/models/spot_tag.rb
+++ b/app/models/spot_tag.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: spot_tags
+#
+#  id         :bigint           not null, primary key
+#  spot_id    :string(255)      not null
+#  tag_id     :string(255)      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 class SpotTag < ApplicationRecord
   belongs_to :spot
   belongs_to :tag

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,3 +1,12 @@
+# == Schema Information
+#
+# Table name: tags
+#
+#  id         :string(255)      not null, primary key
+#  name       :string(255)      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 class Tag < ApplicationRecord
   before_create :set_uuid
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :bigint           not null, primary key
+#  name                   :string(255)      not null
+#  email                  :string(255)      default(""), not null
+#  encrypted_password     :string(255)      default(""), not null
+#  reset_password_token   :string(255)
+#  reset_password_sent_at :datetime
+#  remember_created_at    :datetime
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  provider               :string(255)
+#  uid                    :string(255)
+#
 class User < ApplicationRecord
   devise  :database_authenticatable, :registerable, :recoverable, :rememberable, :validatable,
           :omniauthable, omniauth_providers: [ :google_oauth2 ]

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -1,5 +1,11 @@
 ja:
   activerecord:
+    errors:
+      models:
+        comment:
+          attributes:
+            finish_at:
+              greater_than_or_equal_to: を開始時間よりも遅くしてください
     models:
       user: ユーザー
     attributes:

--- a/config/locales/enums/ja.yml
+++ b/config/locales/enums/ja.yml
@@ -11,6 +11,7 @@ ja:
         pc_work: PC作業
         manual_work: 手作業
         reading: 読書
+        other: その他
       rating:
         star_1: ★
         star_2: ★★

--- a/spec/factories/bookmarks.rb
+++ b/spec/factories/bookmarks.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: bookmarks
+#
+#  id         :bigint           not null, primary key
+#  user_id    :bigint           not null
+#  spot_id    :string(255)      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 FactoryBot.define do
   factory :bookmark do
     association :spot

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: comments
+#
+#  id         :string(255)      not null, primary key
+#  user_id    :bigint           not null
+#  spot_id    :string(255)      not null
+#  scene      :integer          not null
+#  rating     :integer          not null
+#  start_at   :time             not null
+#  finish_at  :time             not null
+#  title      :string(255)      not null
+#  body       :text(65535)      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 FactoryBot.define do
   factory :comment do
     scene { [ 0, 1, 2 ].sample }

--- a/spec/factories/spots.rb
+++ b/spec/factories/spots.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: spots
+#
+#  id         :string(255)      not null, primary key
+#  user_id    :bigint           not null
+#  spot_name  :string(255)      not null
+#  category   :integer          not null
+#  address    :string(255)      not null
+#  body       :text(65535)      not null
+#  latitude   :float(24)
+#  longitude  :float(24)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 FactoryBot.define do
   factory :spot do
     id { nil }

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -1,3 +1,12 @@
+# == Schema Information
+#
+# Table name: tags
+#
+#  id         :string(255)      not null, primary key
+#  name       :string(255)      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 FactoryBot.define do
   factory :tag do
     sequence(:name) { |n| "タグ_#{n}" }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :bigint           not null, primary key
+#  name                   :string(255)      not null
+#  email                  :string(255)      default(""), not null
+#  encrypted_password     :string(255)      default(""), not null
+#  reset_password_token   :string(255)
+#  reset_password_sent_at :datetime
+#  remember_created_at    :datetime
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  provider               :string(255)
+#  uid                    :string(255)
+#
 FactoryBot.define do
   factory :user do
     name { "yuya" }

--- a/spec/models/bookmark_spec.rb
+++ b/spec/models/bookmark_spec.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: bookmarks
+#
+#  id         :bigint           not null, primary key
+#  user_id    :bigint           not null
+#  spot_id    :string(255)      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 require 'rails_helper'
 
 RSpec.describe Bookmark, type: :model do

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Comment, type: :model do
     it "終了時間がない場合、無効である" do
       comment_without_finish_at = build(:comment, finish_at: "")
       expect(comment_without_finish_at).to be_invalid
-      expect(comment_without_finish_at.errors[:finish_at]).to eq [ "を入力してください" ]
+      expect(comment_without_finish_at.errors[:finish_at]).to eq [ "を入力してください", "を入力してください" ]
     end
 
     it "おすすめ度がない場合、無効である" do

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: comments
+#
+#  id         :string(255)      not null, primary key
+#  user_id    :bigint           not null
+#  spot_id    :string(255)      not null
+#  scene      :integer          not null
+#  rating     :integer          not null
+#  start_at   :time             not null
+#  finish_at  :time             not null
+#  title      :string(255)      not null
+#  body       :text(65535)      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 require 'rails_helper'
 
 RSpec.describe Comment, type: :model do

--- a/spec/models/spot_spec.rb
+++ b/spec/models/spot_spec.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: spots
+#
+#  id         :string(255)      not null, primary key
+#  user_id    :bigint           not null
+#  spot_name  :string(255)      not null
+#  category   :integer          not null
+#  address    :string(255)      not null
+#  body       :text(65535)      not null
+#  latitude   :float(24)
+#  longitude  :float(24)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 require 'rails_helper'
 
 RSpec.describe Spot, type: :model do

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -1,3 +1,12 @@
+# == Schema Information
+#
+# Table name: tags
+#
+#  id         :string(255)      not null, primary key
+#  name       :string(255)      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 require "rails_helper"
 
 RSpec.describe Tag, type: :model do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :bigint           not null, primary key
+#  name                   :string(255)      not null
+#  email                  :string(255)      default(""), not null
+#  encrypted_password     :string(255)      default(""), not null
+#  reset_password_token   :string(255)
+#  reset_password_sent_at :datetime
+#  remember_created_at    :datetime
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  provider               :string(255)
+#  uid                    :string(255)
+#
 require 'rails_helper'
 
 RSpec.describe User, type: :model do


### PR DESCRIPTION
### 実装概要
- validationに不足があったため追加実装
  - comment 開始時間よりも終了時間が早くてはいけない
  - enumの値以外は入力できない
    - 未入力の場合、エラーメッセージが複数となってしまうため追加せず

### 実装内容
- comment finish_atはstart_atよりも遅い
  - エラーメッセージを編集
  - エラーメッセージ編集に伴い、テストも変更
- gem annotateインストール
  - 各modelにschema infrmationを記述
- enum の記載方法を変更
  - 公式リファレンスに沿った記述に変更