### PR TITLE
検索機能の修正

### DIFF
--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -92,6 +92,6 @@ class SpotsController < ApplicationController
     end
 
     def search_params
-      params[:q]&.permit(:spot_name, :category, :address, :tag_id, :tag_name)
+      params[:q]&.permit(:spot_tag_name, :category, :address)
     end
 end

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -92,6 +92,6 @@ class SpotsController < ApplicationController
     end
 
     def search_params
-      params[:q]&.permit(:spot_name, :category, :address, :tag_id)
+      params[:q]&.permit(:spot_name, :category, :address, :tag_id, :tag_name)
     end
 end

--- a/app/forms/search_spots_form.rb
+++ b/app/forms/search_spots_form.rb
@@ -2,8 +2,7 @@ class SearchSpotsForm
   include ActiveModel::Model
   include ActiveModel::Attributes
 
-  attribute :spot_name, :string
-  attribute :tag_name, :string
+  attribute :spot_tag_name, :string
   attribute :category, :integer
   attribute :address, :string
   attribute :tag_id, :integer
@@ -11,12 +10,8 @@ class SearchSpotsForm
   def search
     relation = Spot.includes(:image_attachment, :tags).distinct
 
-    spot_name_words.each do |word|
-      relation = relation.spot_name_contain(word)
-    end
-
-    tag_name_words.each do |word|
-      relation = relation.tag_name_contain(word)
+    key_words.each do |word|
+      relation = relation.spot_tag_name_contain(word)
     end
 
     relation = relation.by_category(category) if category.present?
@@ -25,18 +20,13 @@ class SearchSpotsForm
       relation = relation.address_contain(word)
     end
 
-    relation = relation.by_tag(tag_id) if tag_id.present?
     relation
   end
 
   private
 
-    def spot_name_words
-      spot_name.present? ? spot_name.split(nil) : []
-    end
-
-    def tag_name_words
-      tag_name.present? ? tag_name.split(nil) : []
+    def key_words
+      spot_tag_name.present? ? spot_tag_name.split(nil) : []
     end
 
     def address_words

--- a/app/forms/search_spots_form.rb
+++ b/app/forms/search_spots_form.rb
@@ -3,6 +3,7 @@ class SearchSpotsForm
   include ActiveModel::Attributes
 
   attribute :spot_name, :string
+  attribute :tag_name, :string
   attribute :category, :integer
   attribute :address, :string
   attribute :tag_id, :integer
@@ -12,6 +13,10 @@ class SearchSpotsForm
 
     spot_name_words.each do |word|
       relation = relation.spot_name_contain(word)
+    end
+
+    tag_name_words.each do |word|
+      relation = relation.tag_name_contain(word)
     end
 
     relation = relation.by_category(category) if category.present?
@@ -28,6 +33,10 @@ class SearchSpotsForm
 
     def spot_name_words
       spot_name.present? ? spot_name.split(nil) : []
+    end
+
+    def tag_name_words
+      tag_name.present? ? tag_name.split(nil) : []
     end
 
     def address_words

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -33,8 +33,7 @@ class Spot < ApplicationRecord
 
   enum :category, { cafe: 1, work_space: 2, karaoke: 3, other: 4 }
 
-  scope :spot_name_contain, ->(word) { where("spot_name LIKE ?", "%#{word}%") }
-  scope :tag_name_contain, ->(word) { joins(:tags).where( "tags.name LIKE ?", "%#{word}%" ) }
+  scope :spot_tag_name_contain, ->(word) { joins(:tags).where("spot_name LIKE ?", "%#{word}%").or(where( "tags.name LIKE ?", "%#{word}%" )) }
   scope :by_category, ->(category) { where(category: category) }
   scope :address_contain, ->(word) { where("address LIKE ?", "%#{word}%") }
   scope :by_tag, ->(tag_id) { joins(:tags).where(spot_tags: { tag_id: tag_id }) }

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -33,7 +33,7 @@ class Spot < ApplicationRecord
 
   enum :category, { cafe: 1, work_space: 2, karaoke: 3, other: 4 }
 
-  scope :spot_tag_name_contain, ->(word) { joins(:tags).where("spot_name LIKE ?", "%#{word}%").or(where( "tags.name LIKE ?", "%#{word}%" )) }
+  scope :spot_tag_name_contain, ->(word) { joins(:tags).where("spot_name LIKE ?", "%#{word}%").or(where("tags.name LIKE ?", "%#{word}%")) }
   scope :by_category, ->(category) { where(category: category) }
   scope :address_contain, ->(word) { where("address LIKE ?", "%#{word}%") }
   scope :by_tag, ->(tag_id) { joins(:tags).where(spot_tags: { tag_id: tag_id }) }

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -34,6 +34,7 @@ class Spot < ApplicationRecord
   enum :category, { cafe: 1, work_space: 2, karaoke: 3, other: 4 }
 
   scope :spot_name_contain, ->(word) { where("spot_name LIKE ?", "%#{word}%") }
+  scope :tag_name_contain, ->(word) { joins(:tags).where( "tags.name LIKE ?", "%#{word}%" ) }
   scope :by_category, ->(category) { where(category: category) }
   scope :address_contain, ->(word) { where("address LIKE ?", "%#{word}%") }
   scope :by_tag, ->(tag_id) { joins(:tags).where(spot_tags: { tag_id: tag_id }) }

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -5,7 +5,7 @@
 
     <div class="row mb-3 justify-content-center">
       <div class="col-md-9" data-controller="autocomplete" data-autocomplete-url-value="/spots/search" role="combobox">
-        <%= f.search_field :spot_name, class: 'form-control', data: { autocomplete_target: 'input' }, placeholder: "スポット名" %>
+        <%= f.search_field :spot_tag_name, class: 'form-control', data: { autocomplete_target: 'input' }, placeholder: "スポット名" %>
           <ul class="list-group" style="list-style: none; padding-left: 0;" data-autocomplete-target="results"></ul>
       </div>
     </div>

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -4,21 +4,15 @@
   <%= form_with model: @search_spots_form, scope: :q, url: spots_path, method: :get do |f| %>
 
     <div class="row mb-3 justify-content-center">
-      <div class="col-md-9" data-controller="autocomplete" data-autocomplete-url-value="/spots/search" role="combobox">
-        <%= f.search_field :spot_tag_name, class: 'form-control', data: { autocomplete_target: 'input' }, placeholder: "スポット名" %>
-          <ul class="list-group" style="list-style: none; padding-left: 0;" data-autocomplete-target="results"></ul>
-      </div>
-    </div>
-
-    <div class="row justify-content-center">
       <div class="col-md-3 mb-3">
         <%= f.select :category, Spot.categories.map { |k, v| [t("enums.spot.category.#{k}"), v ]} , { include_blank: "カテゴリ" }, class: 'form-control col-3' %>
       </div>
-      <div class="col-md-3 mb-3">
-        <%= f.search_field :address, class: 'form-control', placeholder: "住所" %>
+      <div class="col-md-3 mb-3" data-controller="autocomplete" data-autocomplete-url-value="/spots/search" role="combobox">
+        <%= f.search_field :spot_tag_name, class: 'form-control', data: { autocomplete_target: 'input' }, placeholder: "キーワード　[ 例：店名　Wi-Fi ]" %>
+          <ul class="list-group" style="list-style: none; padding-left: 0;" data-autocomplete-target="results"></ul>
       </div>
       <div class="col-md-3 mb-3">
-        <%= f.search_field :tag_name, class: 'form-control', placeholder: "タグ" %>
+        <%= f.search_field :address, class: 'form-control', placeholder: "エリア" %>
       </div>
     </div>
 
@@ -39,8 +33,12 @@
     </div>
 
     <div id="spots">
-      <% @spots.each do |spot| %>
-        <%= render spot %>
+      <% if @spots.present? %>
+        <% @spots.each do |spot| %>
+          <%= render spot %>
+        <% end %>
+      <% else %>
+        <h2 class="text-center mt-5">一致する検索結果がありません</h2>
       <% end %>
     </div>
   </div>

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -18,7 +18,7 @@
         <%= f.search_field :address, class: 'form-control', placeholder: "住所" %>
       </div>
       <div class="col-md-3 mb-3">
-        <%= f.select :tag_id, Tag.pluck(:name, :id) , { include_blank: "タグ" }, class: 'form-control' %>
+        <%= f.search_field :tag_name, class: 'form-control', placeholder: "タグ" %>
       </div>
     </div>
 


### PR DESCRIPTION
### 実装概要
- UXの観点からタグ検索、店名検索を同じフォームで検索できるようにしたい

### 実装内容
- タグ検索フォームを削除
- 店名検索とタグ検索を同一フォーム内で実施できるように変更
- 各フォームを1段に記述