### PR TITLE
オートコンプリート機能の修正

### DIFF
--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -77,6 +77,7 @@ class SpotsController < ApplicationController
 
   def search
     @spots = Spot.where("spot_name like ?", "%#{params[:q]}%")
+    @tags = Tag.where("name like ?", "%#{params[:q]}%")
     respond_to do |format|
       format.js
     end

--- a/app/views/spots/search.html.erb
+++ b/app/views/spots/search.html.erb
@@ -1,8 +1,7 @@
 <% @spots.each do |spot| %>
   <li class="list-group-item" role="option"><%= spot.spot_name %></li>
 <% end %>
-<% if @tags.present? %>
-  <% @tags.each do |tag| %>
+  <% @tags.each do |tag| if @tags.present?%>
     <li class="list-group-item bg-primary-subtle" role="option"><%= tag.name %></li>
   <% end %>
 <% end %>

--- a/app/views/spots/search.html.erb
+++ b/app/views/spots/search.html.erb
@@ -1,3 +1,8 @@
 <% @spots.each do |spot| %>
   <li class="list-group-item" role="option"><%= spot.spot_name %></li>
 <% end %>
+<% if @tags.present? %>
+  <% @tags.each do |tag| %>
+    <li class="list-group-item bg-primary-subtle" role="option"><%= tag.name %></li>
+  <% end %>
+<% end %>


### PR DESCRIPTION
### 実装概要
- 検索機能を店名、タグを同時に検索できるよう変更したのに伴い、オートコンプリートも変更する
  - 店名だけオートコンプリートが機能していたが、タグにもオートコンプリートを追加する

### 実装内容
- タグのオートコンプリート機能
  - タグの候補を店名の候補と区別するため色を変更